### PR TITLE
fix: issuer url mismatch, ignore trailling `/`

### DIFF
--- a/src/discovery/tests.rs
+++ b/src/discovery/tests.rs
@@ -1158,3 +1158,27 @@ fn test_unsupported_enum_values() {
         serde_json::from_str(&serialized_json).unwrap();
     assert_eq!(provider_metadata, redeserialized_metadata);
 }
+
+#[test]
+fn test_is_issuer_equal() {
+    use crate::discovery::is_issuer_equal;
+
+    assert!(is_issuer_equal(
+        &IssuerUrl::new("https://example.com".to_string()).unwrap(),
+        &IssuerUrl::new("https://example.com".to_string()).unwrap()
+    ));
+    assert!(is_issuer_equal(
+        &IssuerUrl::new("https://example.com".to_string()).unwrap(),
+        &IssuerUrl::new("https://example.com/".to_string()).unwrap()
+    ));
+
+    assert!(is_issuer_equal(
+        &IssuerUrl::new("https://example.com".to_string()).unwrap(),
+        &IssuerUrl::new("https://example.com//".to_string()).unwrap()
+    ));
+
+    assert!(!is_issuer_equal(
+        &IssuerUrl::new("https://example.com1".to_string()).unwrap(),
+        &IssuerUrl::new("https://example.com".to_string()).unwrap()
+    ));
+}


### PR DESCRIPTION
Ignore the trailling `/` when checking the issuer url of the metadata.

https://dev-f578s3iyrreejuhy.jp.auth0.com/.well-known/openid-configuration

<img src="https://github.com/user-attachments/assets/3b683024-c538-4532-a703-2edcb48513dc" with="320" />